### PR TITLE
Feature creation now checks for the output name of the features #37

### DIFF
--- a/giottotime/feature_creation/feature_creation.py
+++ b/giottotime/feature_creation/feature_creation.py
@@ -1,11 +1,39 @@
 from typing import List
 
+import numpy as np
 import pandas as pd
 
 from .base import TimeSeriesFeature
 from .time_series_features import ShiftFeature
 
 __all__ = ["FeatureCreation"]
+
+
+def check_feature_names(time_series_features: List[TimeSeriesFeature]) -> None:
+    """Check that all the output names are different and that there aren't two different
+    features with the same name.
+
+    Parameters
+    ----------
+    time_series_features : ``List[TimeSeriesFeature]``, required.
+        The list of features.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ``ValueError``
+        Raised if there are two features with the same name.
+
+    """
+    feature_output_names = [feature.output_name for feature in time_series_features]
+    if len(set(feature_output_names)) != len(feature_output_names):
+        raise ValueError(
+            "The input features should all have different names, instead "
+            f"they are {feature_output_names}."
+        )
 
 
 class FeatureCreation:
@@ -26,8 +54,10 @@ class FeatureCreation:
     """
 
     def __init__(self, horizon: int, time_series_features: List[TimeSeriesFeature]):
-        self.time_series_features = time_series_features
-        self.horizon = horizon
+        check_feature_names(time_series_features)
+
+        self._time_series_features = time_series_features
+        self._horizon = horizon
 
     def fit_transform(self, time_series: pd.DataFrame) -> (pd.DataFrame, pd.DataFrame):
         """Create the X matrix by generating the feature_creation, starting
@@ -66,7 +96,7 @@ class FeatureCreation:
 
         """
         y = pd.DataFrame(index=time_series.index)
-        for k in range(self.horizon):
+        for k in range(self._horizon):
             shift_feature = ShiftFeature(-k, f"shift_{k}")
             y[f"y_{k}"] = shift_feature.fit_transform(time_series)
 
@@ -88,7 +118,7 @@ class FeatureCreation:
 
         """
         features = pd.DataFrame(index=time_series.index)
-        for time_series_feature in self.time_series_features:
+        for time_series_feature in self._time_series_features:
             x_transformed = time_series_feature.fit_transform(time_series)
             features = pd.concat([features, x_transformed], axis=1)
 


### PR DESCRIPTION
All the features in the FeatureCreation class should have different a different output_name. This check is not implemented in the constructor of the FeatureCreation object.