### PR TITLE
Fix in the direction of the shift #98

### DIFF
--- a/giottotime/causality_tests/shifted_linear_coefficient.py
+++ b/giottotime/causality_tests/shifted_linear_coefficient.py
@@ -120,7 +120,9 @@ class ShiftedLinearCoefficient(CausalityTest):
 
         for col in data_t:
             if col != self.target_col:
-                data_t[col] = data_t[col].shift(self.best_shifts_[col][self.target_col])
+                data_t[col] = data_t[col].shift(
+                    -self.best_shifts_[col][self.target_col]
+                )
 
         if self.dropna:
             data_t = data_t.dropna()

--- a/giottotime/causality_tests/shifted_pearson_correlation.py
+++ b/giottotime/causality_tests/shifted_pearson_correlation.py
@@ -118,7 +118,9 @@ class ShiftedPearsonCorrelation(CausalityTest):
 
         for col in data_t:
             if col != self.target_col:
-                data_t[col] = data_t[col].shift(self.best_shifts_[col][self.target_col])
+                data_t[col] = data_t[col].shift(
+                    -self.best_shifts_[col][self.target_col]
+                )
 
         if self.dropna:
             data_t = data_t.dropna()

--- a/giottotime/causality_tests/tests/test_causality_tests.py
+++ b/giottotime/causality_tests/tests/test_causality_tests.py
@@ -72,5 +72,5 @@ def shift_df_from_expected_shifts(
     df: pd.DataFrame, expected_shifts: List[int]
 ) -> pd.DataFrame:
     for sh, k in zip(expected_shifts, range(3)):
-        df[f"shift_{k}"] = df[f"shift_{k}"].shift(sh)
+        df[f"shift_{k}"] = df[f"shift_{k}"].shift(-sh)
     return df.dropna()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-time/blob/master/CONTRIBUTING.md#pull-request-checklist
-->
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes issue #98

#### What does this implement/fix? Explain your changes.
Fixing a bug that was causing the shift of the transform in the causality test to be in the wrong way. After finding the best shift n, the transform should shift back with -n, instead was adding another shift equal to n.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
