### PR TITLE
added MovingCustomFeature

### DIFF
--- a/giottotime/feature_creation/__init__.py
+++ b/giottotime/feature_creation/__init__.py
@@ -14,6 +14,7 @@ from .index_dependent_features import (
 from .index_dependent_features import (
     ShiftFeature,
     MovingAverageFeature,
+    MovingCustomFeature,
     PolynomialFeature,
     ExogenousFeature,
     AmplitudeFeature,

--- a/giottotime/feature_creation/index_dependent_features/__init__.py
+++ b/giottotime/feature_creation/index_dependent_features/__init__.py
@@ -3,6 +3,7 @@ from .calendar_features import CalendarFeature
 from .time_series_features import (
     ShiftFeature,
     MovingAverageFeature,
+    MovingCustomFeature,
     PolynomialFeature,
     ExogenousFeature,
 )

--- a/giottotime/feature_creation/index_dependent_features/time_series_features.py
+++ b/giottotime/feature_creation/index_dependent_features/time_series_features.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Callable
 
 import pandas as pd
 from sklearn.preprocessing import PolynomialFeatures
@@ -121,6 +121,81 @@ class MovingAverageFeature(IndexDependentFeature):
         """
         time_series_mvg_avg = time_series.rolling(self.window_size).mean()
         time_series_t = self._rename_columns(time_series_mvg_avg)
+        return time_series_t
+
+
+class MovingCustomFeature(IndexDependentFeature):
+    """For each row in ``time_series``, compute the moving custom function of the
+    previous ``window_size`` rows. If there are not enough rows, the value is Nan.
+
+    Parameters
+    ----------
+    custom_feature_function : Callable, required.
+        The function to use to generate a ``pd.DataFrame`` containing the feature.
+
+    window_size : int, optional, default: ``1``
+        The number of previous points on which to compute the custom function
+
+    output_name : str, optional, default: ``'MovingAverageFeature'``
+        The name of the output column.
+
+    raw : bool, optional, default: ``True``
+        - False : passes each row or column as a Series to the function.
+        - True or None : the passed function will receive ndarray objects instead.
+         If you are just applying a NumPy reduction function this will achieve much
+         better performance. Credits: https://pandas.pydata.org/pandas-docs/stable/
+         reference/api/pandas.core.window.Rolling.apply.html
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from giottotime.feature_creation import MovingCustomFeature
+    >>> ts = pd.DataFrame([0, 1, 2, 3, 4, 5])
+    >>> mv_cust_feature = MovingCustomFeature(np.max,window_size=2)
+    >>> mv_cust_feature.transform(ts)
+       MovingCustomFeature
+    0                   NaN
+    1                   1.0
+    2                   2.0
+    3                   3.0
+    4                   4.0
+    5                   5.0
+
+    """
+
+    def __init__(
+        self,
+        custom_feature_function: Callable,
+        window_size: int = 1,
+        output_name: str = "MovingCustomFeature",
+        raw: bool = True,
+    ):
+        super().__init__(output_name)
+        self.custom_feature_function = custom_feature_function
+        self.window_size = window_size
+        self.raw =  raw
+
+
+    def transform(self, time_series: pd.DataFrame) -> pd.DataFrame:
+        """compute the moving custom function, for every row of ``time_series``, of the
+         previous ``window_size`` elements.
+
+        Parameters
+        ----------
+        time_series : pd.DataFrame, shape (n_samples, 1), required
+            The DataFrame on which to compute the rolling moving custom function
+
+        Returns
+        -------
+        time_series_t : pd.DataFrame, shape (n_samples, 1)
+            A DataFrame, with the same length as ``time_series``, containing the rolling
+            moving custom funcyion for each element.
+
+        """
+        time_series_mvg_cust = time_series.rolling(self.window_size)\
+                                          .apply(self.custom_feature_function,raw=self.raw)
+        time_series_t = self._rename_columns(time_series_mvg_cust)
         return time_series_t
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-time/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Added MovingCustomFeature class in feature_creation.index_dependent_features.time_series_features. It's analogous to MovingAverageFeature, but it allows for custom functions (exploiting https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.window.Rolling.apply.html).

#### Any other comments?

I installed it locally by using setup.py and it works, but I did not implement tests.


<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->