### PR TITLE
Refactor of causality test #112 and min_shift introduced #110

### DIFF
--- a/giottotime/causality/base.py
+++ b/giottotime/causality/base.py
@@ -26,7 +26,7 @@ class CausalityMixin:
         -------
         data_t : pd.DataFrame, shape (n_samples, n_time_series)
             The DataFrame (Pivot table) of the shifts which maximize the correlation
-            between each time series The shift is indicated in rows.
+            between each time series. The shift is indicated in rows.
 
         """
         check_is_fitted(self)

--- a/giottotime/causality/base.py
+++ b/giottotime/causality/base.py
@@ -1,13 +1,86 @@
+from itertools import product
+
+import numpy as np
 import pandas as pd
 from scipy import stats
+from sklearn.utils.validation import check_is_fitted
 
 
 class CausalityMixin:
     """ Base class for causality tests. """
 
-    def __init__(self, bootstrap_iterations, bootstrap_samples):
+    def __init__(self, bootstrap_iterations):
         self.bootstrap_iterations = bootstrap_iterations
-        self.bootstrap_samples = bootstrap_samples
+
+    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Shifts each input time series by the amount which optimizes correlation with
+        the selected 'y' column.
+
+        Parameters
+        ----------
+        data : pd.DataFrame, shape (n_samples, n_time_series), required
+            The DataFrame containing the time series on which to perform the
+            transformation.
+
+        Returns
+        -------
+        data_t : pd.DataFrame, shape (n_samples, n_time_series)
+            The DataFrame (Pivot table) of the shifts which maximize the correlation
+            between each time series The shift is indicated in rows.
+
+        """
+        check_is_fitted(self)
+        data_t = data.copy()
+
+        for col in data_t:
+            if col != self.target_col:
+                data_t[col] = data_t[col].shift(
+                    -self.best_shifts_[col][self.target_col]
+                )
+
+        if self.dropna:
+            data_t = data_t.dropna()
+
+        return data_t
+
+    def _initialize_table(self):
+        best_shifts = pd.DataFrame(columns=["x", "y", "shift", "max_corr"])
+        column_types = {
+            "x": np.float64,
+            "y": np.float64,
+            "shift": np.int64,
+            "max_corr": np.int64,
+        }
+
+        if self.bootstrap_iterations:
+            best_shifts = best_shifts.reindex(
+                best_shifts.columns.tolist() + ["p_values"], axis=1
+            )
+            column_types["p_values"] = np.float64
+
+        best_shifts = best_shifts.astype(column_types)
+        return best_shifts
+
+    def _compute_best_shifts(self, data, shift_func):
+        best_shifts = self._initialize_table()
+
+        for x, y in product(data.columns, repeat=2):
+            res = shift_func(data, x=x, y=y)
+            best_shift = res[1]
+            max_corr = res[0]
+            tables = {
+                "x": x,
+                "y": y,
+                "shift": best_shift,
+                "max_corr": max_corr,
+            }
+            if self.bootstrap_iterations:
+                p_value = self._compute_is_test_significant(data, x, y, best_shift)
+                tables["p_values"] = p_value
+
+            best_shifts = best_shifts.append(tables, ignore_index=True,)
+
+        return best_shifts
 
     def _compute_is_test_significant(self, data, x, y, best_shift):
         bootstrap_matrix = data.copy()
@@ -24,3 +97,21 @@ class CausalityMixin:
         p_value = 2 * (percentile if percentile < 0.5 else 1 - percentile)
 
         return p_value
+
+    def _create_pivot_tables(self, best_shifts):
+        pivot_best_shifts = pd.pivot_table(
+            best_shifts, index=["x"], columns=["y"], values="shift"
+        )
+        max_corrs = pd.pivot_table(
+            best_shifts, index=["x"], columns=["y"], values="max_corr"
+        )
+
+        pivot_tables = {"best_shifts": pivot_best_shifts, "max_corrs": max_corrs}
+
+        if self.bootstrap_iterations:
+            p_values = pd.pivot_table(
+                best_shifts, index=["x"], columns=["y"], values="p_values"
+            )
+            pivot_tables["p_values"] = p_values
+
+        return pivot_tables

--- a/giottotime/causality/pearson_correlation.py
+++ b/giottotime/causality/pearson_correlation.py
@@ -1,9 +1,5 @@
-from itertools import product
-
 import pandas as pd
-import numpy as np
 from sklearn.base import TransformerMixin, BaseEstimator
-from sklearn.utils.validation import check_is_fitted
 
 from giottotime.causality.base import CausalityMixin
 
@@ -15,7 +11,11 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
 
     Parameters
     ----------
+    min_shift : int, optional, default: ``1``
+        The minimum number of shifts to check for.
+
     max_shift : int, optional, default: ``10``
+        The maximum number of shifts to check for.
 
     target_col : str, optional, default: ``'y'``
             The column to use as the a reference (i.e., the columns which is not
@@ -23,6 +23,9 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
 
     dropna : bool, optional, default: ``False``
         Determines if the Nan values created by shifting are retained or dropped.
+
+    bootstrap_iterations : int, optional, default: ``None``
+        If not None, compute the p_values of the test, by performing bootstrap.
 
     Examples
     --------
@@ -49,13 +52,14 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
 
     def __init__(
         self,
+        min_shift: int = 1,
         max_shift: int = 10,
         target_col: str = "y",
         dropna: bool = False,
-        bootstrap_iterations=1000,
-        bootstrap_samples=100,
+        bootstrap_iterations: int = None,
     ):
-        super().__init__(bootstrap_iterations, bootstrap_samples)
+        super().__init__(bootstrap_iterations=bootstrap_iterations)
+        self.min_shift = min_shift
         self.max_shift = max_shift
         self.target_col = target_col
         self.dropna = dropna
@@ -75,88 +79,22 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
         self : ``ShiftedPearsonCorrelation``
 
         """
-        best_shifts = pd.DataFrame(columns=["x", "y", "shift", "max_corr", "p_values"])
-        best_shifts = best_shifts.astype(
-            {
-                "x": np.float64,
-                "y": np.float64,
-                "shift": np.int64,
-                "max_corr": np.int64,
-                "p_values": np.float64,
-            }
-        )
+        best_shifts = self._compute_best_shifts(data, self._get_max_corr_shift)
 
-        for x, y in product(data.columns, repeat=2):
-            res = self._get_max_corr_shift(data, self.max_shift, x=x, y=y)
-            best_shift = res[1]
-            max_corr = res[0]
-            p_value = self._compute_is_test_significant(data, x, y, best_shift)
-            # N = data.shape[0] - max_shift
+        pivot_tables = self._create_pivot_tables(best_shifts)
 
-            best_shifts = best_shifts.append(
-                {
-                    "x": x,
-                    "y": y,
-                    "shift": best_shift,
-                    "max_corr": max_corr,
-                    "p_values": p_value,
-                },
-                ignore_index=True,
-            )
+        self.best_shifts_ = pivot_tables["best_shifts"]
+        self.max_corrs_ = pivot_tables["max_corrs"]
 
-        pivot_best_shifts = pd.pivot_table(
-            best_shifts, index=["x"], columns=["y"], values="shift"
-        )
-        max_corrs = pd.pivot_table(
-            best_shifts, index=["x"], columns=["y"], values="max_corr"
-        )
-        p_values = pd.pivot_table(
-            best_shifts, index=["x"], columns=["y"], values="p_values"
-        )
-
-        self.best_shifts_ = pivot_best_shifts
-        self.max_corrs_ = max_corrs
-        self.p_values_ = p_values
+        if self.bootstrap_iterations:
+            self.p_values_ = pivot_tables["p_values"]
 
         return self
 
-    def transform(self, data: pd.DataFrame) -> pd.DataFrame:
-        """Shifts each input time series by the amount which optimizes correlation with
-        the selected 'y' column.
-
-        Parameters
-        ----------
-        data : pd.DataFrame, shape (n_samples, n_time_series), required
-            The DataFrame containing the time series on which to perform the
-            transformation.
-
-        Returns
-        -------
-        data_t : pd.DataFrame, shape (n_samples, n_time_series)
-            The DataFrame (Pivot table) of the shifts which maximize the correlation
-            between each time series The shift is indicated in rows.
-
-        """
-        check_is_fitted(self)
-        data_t = data.copy()
-
-        for col in data_t:
-            if col != self.target_col:
-                data_t[col] = data_t[col].shift(
-                    -self.best_shifts_[col][self.target_col]
-                )
-
-        if self.dropna:
-            data_t = data_t.dropna()
-
-        return data_t
-
-    def _get_max_corr_shift(
-        self, data: pd.DataFrame, max_shift: int, x: str = "x", y: str = "y"
-    ):
+    def _get_max_corr_shift(self, data: pd.DataFrame, x, y):
         shifts = pd.DataFrame()
 
-        for shift in range(1, max_shift):
+        for shift in range(self.min_shift, self.max_shift):
             shifts[shift] = data[x].shift(shift)
 
         shifts = shifts.dropna()

--- a/giottotime/causality/tests/test_linear_coefficient.py
+++ b/giottotime/causality/tests/test_linear_coefficient.py
@@ -43,7 +43,7 @@ def test_linear_p_values():
     expected_shifts = [randint(2, 9) * 2 for _ in range(3)]
     df = make_df_from_expected_shifts(expected_shifts)
     shifted_test = ShiftedLinearCoefficient(
-        target_col="A", max_shift=5, bootstrap_iterations=500, bootstrap_samples=1000,
+        target_col="A", max_shift=5, bootstrap_iterations=500,
     )
     shifted_test.fit(df)
 

--- a/giottotime/causality/tests/test_pearson_correlation.py
+++ b/giottotime/causality/tests/test_pearson_correlation.py
@@ -3,10 +3,7 @@ from random import randint
 import numpy as np
 
 from giottotime.causality import ShiftedPearsonCorrelation
-from giottotime.causality.tests.common import (
-    make_df_from_expected_shifts,
-    shift_df_from_expected_shifts,
-)
+from giottotime.causality.tests.common import make_df_from_expected_shifts
 
 
 def test_pearson_correlation():
@@ -24,7 +21,7 @@ def test_pearson_p_values():
     expected_shifts = [randint(2, 9) * 2 for _ in range(3)]
     df = make_df_from_expected_shifts(expected_shifts)
     shifted_test = ShiftedPearsonCorrelation(
-        target_col="A", max_shift=5, bootstrap_iterations=500, bootstrap_samples=1000,
+        target_col="A", max_shift=5, bootstrap_iterations=500,
     )
     shifted_test.fit(df)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-time/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Issue #110 and #112

#### What does this implement/fix? Explain your changes.
- min_shift: the causality tests now allow the user to select a min_shift. This could be helpful if the user does not want to test for shifts below a certain value. 
- refactor: the duplicated code has now been removed and put it in the CausalityMixin base class.