### PR TITLE
Causality test features

### DIFF
--- a/gtime/causality/linear_coefficient.py
+++ b/gtime/causality/linear_coefficient.py
@@ -17,7 +17,7 @@ class ShiftedLinearCoefficient(BaseEstimator, TransformerMixin, CausalityMixin):
     max_shift : int, optional, default: ``10``
         The maximum number of shifts to check for.
 
-    target_col : str, optional, default: ``'y'``
+    target_col : str, optional, default: ``None``
         The column to use as the a reference (i.e., the column which is not
         shifted).
 
@@ -55,7 +55,7 @@ class ShiftedLinearCoefficient(BaseEstimator, TransformerMixin, CausalityMixin):
         self,
         min_shift: int = 1,
         max_shift: int = 10,
-        target_col: str = "y",
+        target_col: str = None,
         dropna: bool = False,
         bootstrap_iterations: int = None,
     ):
@@ -97,7 +97,7 @@ class ShiftedLinearCoefficient(BaseEstimator, TransformerMixin, CausalityMixin):
         shifts[x] = data[x]
         shifts[y] = data[y]
 
-        for shift in range(self.min_shift, self.max_shift + 1):
+        for shift in range(self.min_shift, self.max_shift + 10):
             shifts[shift] = data[x].shift(shift)
 
         shifts = shifts.dropna()
@@ -105,5 +105,5 @@ class ShiftedLinearCoefficient(BaseEstimator, TransformerMixin, CausalityMixin):
             shifts[range(self.min_shift, self.max_shift + 1)].values, shifts[y].values
         )
 
-        q = lf.coef_.max(), np.argmax(lf.coef_) + 1
+        q = lf.coef_.max(), np.argmax(lf.coef_) + (self.min_shift - 0)
         return q

--- a/gtime/causality/pearson_correlation.py
+++ b/gtime/causality/pearson_correlation.py
@@ -17,7 +17,7 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
     max_shift : int, optional, default: ``10``
         The maximum number of shifts to check for.
 
-    target_col : str, optional, default: ``'y'``
+    target_col : str, optional, default: ``None``
             The column to use as the a reference (i.e., the columns which is not
             shifted).
 
@@ -54,7 +54,7 @@ class ShiftedPearsonCorrelation(BaseEstimator, TransformerMixin, CausalityMixin)
         self,
         min_shift: int = 1,
         max_shift: int = 10,
-        target_col: str = "y",
+        target_col: str = None,
         dropna: bool = False,
         bootstrap_iterations: int = None,
     ):

--- a/gtime/causality/tests/common.py
+++ b/gtime/causality/tests/common.py
@@ -9,7 +9,7 @@ def make_df_from_expected_shifts(expected_shifts: List[int]) -> pd.DataFrame:
 
     df = testing.makeTimeDataFrame(freq="D")
     for sh, k in zip(expected_shifts, range(3)):
-        df[f"shift_{k}"] = df["A"].shift(sh)
+        df[f"shift_{k}"] = df["A"].shift(-sh)
     df = df.dropna()
 
     return df
@@ -19,5 +19,5 @@ def shift_df_from_expected_shifts(
     df: pd.DataFrame, expected_shifts: List[int]
 ) -> pd.DataFrame:
     for sh, k in zip(expected_shifts, range(3)):
-        df[f"shift_{k}"] = df[f"shift_{k}"].shift(sh)
+        df[f"shift_{k}"] = df[f"shift_{k}"].shift(-sh)
     return df.dropna()

--- a/gtime/causality/tests/test_linear_coefficient.py
+++ b/gtime/causality/tests/test_linear_coefficient.py
@@ -6,21 +6,17 @@ from hypothesis import given, strategies as st
 from pandas.util import testing as testing
 
 from gtime.causality import ShiftedLinearCoefficient
-
-from gtime.causality.tests.common import (
-    make_df_from_expected_shifts,
-    shift_df_from_expected_shifts,
-)
+from gtime.causality.tests.common import make_df_from_expected_shifts
 
 
 def test_linear_coefficient():
     expected_shifts = [randint(2, 9) * 2 for _ in range(3)]
-    df = make_df_from_expected_shifts(expected_shifts)
 
+    df = make_df_from_expected_shifts(expected_shifts)
     slc = ShiftedLinearCoefficient(target_col="A", max_shift=20)
     slc.fit(df)
 
-    shifts = slc.best_shifts_.loc["A"][1:].values
+    shifts = slc.best_shifts_["A"][1:].values
     np.testing.assert_array_equal(shifts, expected_shifts)
 
 

--- a/gtime/causality/tests/test_pearson_correlation.py
+++ b/gtime/causality/tests/test_pearson_correlation.py
@@ -13,7 +13,7 @@ def test_pearson_correlation():
     spc = ShiftedPearsonCorrelation(target_col="A", max_shift=20)
     spc.fit(df)
 
-    shifts = spc.best_shifts_.loc["A"][1:].values
+    shifts = spc.best_shifts_["A"][1:].values
     np.testing.assert_array_equal(shifts, expected_shifts)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-time/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
#108 

#### What does this implement/fix? Explain your changes.
Now the `targer_col` parameter is not mandatory. If provided, the correlation is computed only with respect to the specified target column. If not provided, the correlation is computed between all the possible pair of columns. In this latter case, in the transform the first column is used as target _col (and a warning is raised). 
