### PR TITLE
Naïve and simple average models

### DIFF
--- a/gtime/forecasting/__init__.py
+++ b/gtime/forecasting/__init__.py
@@ -5,7 +5,7 @@ for dealing with time series data.
 
 from .gar import GAR, GARFF
 from .trend_models import TrendForecaster
-from.simple_models import NaiveForecaster, SeasonalNaiveForecaster
+from.simple_models import NaiveForecaster, SeasonalNaiveForecaster, MovingAverageForecaster
 
 __all__ = [
     "GAR",
@@ -13,4 +13,5 @@ __all__ = [
     "TrendForecaster",
     "NaiveForecaster",
     "SeasonalNaiveForecaster",
+    "MovingAverageForecaster",
 ]

--- a/gtime/forecasting/__init__.py
+++ b/gtime/forecasting/__init__.py
@@ -5,9 +5,12 @@ for dealing with time series data.
 
 from .gar import GAR, GARFF
 from .trend_models import TrendForecaster
+from.simple_models import NaiveForecaster, SeasonalNaiveForecaster
 
 __all__ = [
     "GAR",
     "GARFF",
     "TrendForecaster",
+    "NaiveForecaster",
+    "SeasonalNaiveForecaster",
 ]

--- a/gtime/forecasting/simple_models.py
+++ b/gtime/forecasting/simple_models.py
@@ -4,17 +4,13 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
 
 
-
 class NaiveForecaster(BaseEstimator, RegressorMixin):
     """Naive forecasting model.
     TDB
 
     """
 
-    def __init__(
-
-        self,
-    ):
+    def __init__(self,):
         """
         Not needed here really but let it be for compatibility
         """
@@ -75,9 +71,7 @@ class SeasonalNaiveForecaster(NaiveForecaster):
     """
 
     def __init__(
-
-        self,
-        seasonal_length = 1,
+        self, seasonal_length=1,
     ):
         """
         Not needed here really but let it be for compatibility
@@ -103,7 +97,7 @@ class SeasonalNaiveForecaster(NaiveForecaster):
             Returns self.
 
         """
-        self.next_value_ = X.iloc[-self.lag:]
+        self.next_value_ = X.iloc[-self.lag :]
 
         return self
 
@@ -129,7 +123,10 @@ class SeasonalNaiveForecaster(NaiveForecaster):
         check_is_fitted(self)
 
         len_x = len(X)
-        y_pred = list(self.next_value_.values) * (len_x // self.lag) + list(self.next_value_.values)[:(len_x % self.lag)]
+        y_pred = (
+            list(self.next_value_.values) * (len_x // self.lag)
+            + list(self.next_value_.values)[: (len_x % self.lag)]
+        )
 
         predictions = pd.DataFrame(data=y_pred, index=X.index)
 
@@ -143,9 +140,7 @@ class MovingAverageForecaster(BaseEstimator, RegressorMixin):
     """
 
     def __init__(
-
-        self,
-        window: int,
+        self, window: int,
     ):
         """
         Not needed here really but let it be for compatibility
@@ -172,7 +167,7 @@ class MovingAverageForecaster(BaseEstimator, RegressorMixin):
             Returns self.
 
         """
-        self.next_value_ = X.iloc[-self.window:].mean()
+        self.next_value_ = X.iloc[-self.window :].mean()
 
         return self
 
@@ -198,5 +193,7 @@ class MovingAverageForecaster(BaseEstimator, RegressorMixin):
 
         check_is_fitted(self)
 
-        predictions = pd.DataFrame(data=self.next_value_.values, index=X.index, columns=X.columns)
+        predictions = pd.DataFrame(
+            data=self.next_value_.values, index=X.index, columns=X.columns
+        )
         return predictions

--- a/gtime/forecasting/simple_models.py
+++ b/gtime/forecasting/simple_models.py
@@ -123,12 +123,14 @@ class SeasonalNaiveForecaster(NaiveForecaster):
         check_is_fitted(self)
 
         len_x = len(X)
-        y_pred = (
-            list(self.next_value_.values) * (len_x // self.lag)
-            + list(self.next_value_.values)[: (len_x % self.lag)]
+        forecast = self.next_value_[X.columns].to_numpy()
+        len_f = len(forecast)
+        y_pred = np.concatenate(
+            (np.tile(forecast, (len_x // len_f, 1)), forecast[: (len_x % len_f), :]),
+            axis=0,
         )
 
-        predictions = pd.DataFrame(data=y_pred, index=X.index)
+        predictions = pd.DataFrame(data=y_pred, index=X.index, columns=X.columns)
 
         return predictions
 
@@ -193,7 +195,10 @@ class MovingAverageForecaster(BaseEstimator, RegressorMixin):
 
         check_is_fitted(self)
 
+        y_pred = self.next_value_[X.columns].to_numpy()
+        len_x = len(X)
+
         predictions = pd.DataFrame(
-            data=self.next_value_.values, index=X.index, columns=X.columns
+            data=np.tile(y_pred, (len_x, 1)), index=X.index, columns=X.columns
         )
         return predictions

--- a/gtime/forecasting/simple_models.py
+++ b/gtime/forecasting/simple_models.py
@@ -8,30 +8,8 @@ from sklearn.utils.validation import check_is_fitted
 
 
 class NaiveForecaster(BaseEstimator, RegressorMixin):
-    """Trend forecasting model.
-
-    This estimator optimizes a trend function on train data and will forecast using this trend function with optimized
-    parameters.
-
-    Parameters
-    ----------
-
-
-    Examples
-    --------
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> from gtime.model_selection import horizon_shift, FeatureSplitter
-    >>> from gtime.forecasting import TrendForecaster
-    >>>
-    >>> X = pd.DataFrame(np.random.random((10, 1)), index=pd.date_range("2020-01-01", "2020-01-10"))
-    >>> y = horizon_shift(X, horizon=2)
-    >>> X_train, y_train, X_test, y_test = FeatureSplitter().transform(X, y)
-    >>>
-    >>> tf = TrendForecaster(trend='polynomial', trend_x0=np.zeros(2))
-    >>> tf.fit(X_train).predict(X_test)
-    array([[0.39703029],
-           [0.41734957]])
+    """Naive forecasting model.
+    TDB
 
     """
 
@@ -92,6 +70,11 @@ class NaiveForecaster(BaseEstimator, RegressorMixin):
 
 
 class SeasonalNaiveForecaster(NaiveForecaster):
+
+    """Seasonal naive forecasting model.
+    TDB
+
+    """
 
     def __init__(
 

--- a/gtime/forecasting/simple_models.py
+++ b/gtime/forecasting/simple_models.py
@@ -1,0 +1,155 @@
+from typing import Callable
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, RegressorMixin
+from sklearn.utils.validation import check_is_fitted
+
+
+
+class NaiveForecaster(BaseEstimator, RegressorMixin):
+    """Trend forecasting model.
+
+    This estimator optimizes a trend function on train data and will forecast using this trend function with optimized
+    parameters.
+
+    Parameters
+    ----------
+
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from gtime.model_selection import horizon_shift, FeatureSplitter
+    >>> from gtime.forecasting import TrendForecaster
+    >>>
+    >>> X = pd.DataFrame(np.random.random((10, 1)), index=pd.date_range("2020-01-01", "2020-01-10"))
+    >>> y = horizon_shift(X, horizon=2)
+    >>> X_train, y_train, X_test, y_test = FeatureSplitter().transform(X, y)
+    >>>
+    >>> tf = TrendForecaster(trend='polynomial', trend_x0=np.zeros(2))
+    >>> tf.fit(X_train).predict(X_test)
+    array([[0.39703029],
+           [0.41734957]])
+
+    """
+
+    def __init__(
+
+        self,
+    ):
+        """
+        Not needed here really but let it be for compatibility
+        """
+        self.next_value_ = None
+
+    def fit(self, X: pd.DataFrame, y=None) -> "NaiveForecaster":
+        """Fit the estimator.
+
+        Parameters
+        ----------
+        X : pd.DataFrame, shape (n_samples, n_features), required
+            Input data.
+
+        y : None
+            There is no need of a target in a transformer, yet the pipeline API
+            requires this parameter.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        self.next_value_ = X.iloc[-1]
+
+        return self
+
+    def predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Using the fitted polynomial, predict the values starting from ``X``.
+
+        Parameters
+        ----------
+        X: pd.DataFrame, shape (n_samples, 1), required
+            The time series on which to predict.
+
+        Returns
+        -------
+        predictions : pd.DataFrame, shape (n_samples, 1)
+            The output predictions.
+
+        Raises
+        ------
+        NotFittedError
+            Raised if the model is not fitted yet.
+
+        """
+        check_is_fitted(self)
+
+        predictions = pd.DataFrame(data=self.next_value_, index=X.index)
+        return predictions
+
+
+class SeasonalNaiveForecaster(NaiveForecaster):
+
+    def __init__(
+
+        self,
+        seasonal_length = 1,
+    ):
+        """
+        Not needed here really but let it be for compatibility
+        """
+        super().__init__()
+        self.lag = seasonal_length
+
+    def fit(self, X: pd.DataFrame, y=None) -> "SeasonalNaiveForecaster":
+        """Fit the estimator.
+
+        Parameters
+        ----------
+        X : pd.DataFrame, shape (n_samples, n_features), required
+            Input data.
+
+        y : None
+            There is no need of a target in a transformer, yet the pipeline API
+            requires this parameter.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        self.next_value_ = X.iloc[-self.lag:]
+
+        return self
+
+    def predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Using the fitted polynomial, predict the values starting from ``X``.
+
+        Parameters
+        ----------
+        X: pd.DataFrame, shape (n_samples, 1), required
+            The time series on which to predict.
+
+        Returns
+        -------
+        predictions : pd.DataFrame, shape (n_samples, 1)
+            The output predictions.
+
+        Raises
+        ------
+        NotFittedError
+            Raised if the model is not fitted yet.
+
+        """
+        check_is_fitted(self)
+
+        len_x = len(X)
+        y_pred = list(self.next_value_.values) * (len_x // self.lag) + list(self.next_value_.values)[:(len_x % self.lag)]
+
+        predictions = pd.DataFrame(data=y_pred, index=X.index)
+
+        return predictions

--- a/gtime/forecasting/simple_models.py
+++ b/gtime/forecasting/simple_models.py
@@ -1,5 +1,3 @@
-from typing import Callable
-
 import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator, RegressorMixin
@@ -135,4 +133,70 @@ class SeasonalNaiveForecaster(NaiveForecaster):
 
         predictions = pd.DataFrame(data=y_pred, index=X.index)
 
+        return predictions
+
+
+class MovingAverageForecaster(BaseEstimator, RegressorMixin):
+    """Naive forecasting model.
+    TDB
+
+    """
+
+    def __init__(
+
+        self,
+        window: int,
+    ):
+        """
+        Not needed here really but let it be for compatibility
+        """
+
+        self.window = window
+        self.next_value_ = None
+
+    def fit(self, X: pd.DataFrame, y=None) -> "MovingAverageForecaster":
+        """Fit the estimator.
+
+        Parameters
+        ----------
+        X : pd.DataFrame, shape (n_samples, n_features), required
+            Input data.
+
+        y : None
+            There is no need of a target in a transformer, yet the pipeline API
+            requires this parameter.
+
+        Returns
+        -------
+        self : object
+            Returns self.
+
+        """
+        self.next_value_ = X.iloc[-self.window:].mean()
+
+        return self
+
+    def predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Using the fitted polynomial, predict the values starting from ``X``.
+
+        Parameters
+        ----------
+        X: pd.DataFrame, shape (n_samples, 1), required
+            The time series on which to predict.
+
+        Returns
+        -------
+        predictions : pd.DataFrame, shape (n_samples, 1)
+            The output predictions.
+
+        Raises
+        ------
+        NotFittedError
+            Raised if the model is not fitted yet.
+
+        """
+
+        check_is_fitted(self)
+
+        predictions = pd.DataFrame(data=self.next_value_.values, index=X.index, columns=X.columns)
         return predictions

--- a/gtime/forecasting/tests/test_simple_models.py
+++ b/gtime/forecasting/tests/test_simple_models.py
@@ -3,8 +3,11 @@ import pandas as pd
 import pytest
 from pandas.util import testing as testing
 
-from gtime.forecasting import NaiveForecaster, SeasonalNaiveForecaster, MovingAverageForecaster
-
+from gtime.forecasting import (
+    NaiveForecaster,
+    SeasonalNaiveForecaster,
+    MovingAverageForecaster,
+)
 
 
 @pytest.fixture()
@@ -12,9 +15,7 @@ def generate_ts():
     testing.N, testing.K = 500, 1
     df = testing.makeTimeDataFrame(freq="D")
 
-    df["A"] = df["A"] + 0.0005 * pd.Series(
-        index=df.index, data=range(df.shape[0])
-    )
+    df["A"] = df["A"] + 0.0005 * pd.Series(index=df.index, data=range(df.shape[0]))
     return df
 
 
@@ -24,7 +25,7 @@ def test_naive_fit(generate_ts):
 
     tm = NaiveForecaster()
     tm.fit(train)
-    assert tm.next_value_['A'] == train.iloc[-1]['A']
+    assert tm.next_value_["A"] == train.iloc[-1]["A"]
 
 
 def test_naive_predict(generate_ts):
@@ -46,7 +47,7 @@ def test_snaive_fit(generate_ts):
     tm = SeasonalNaiveForecaster(seasonal_length=s)
     tm.fit(train)
 
-    assert all(tm.next_value_['A'] == train.iloc[-s:]['A'])
+    assert all(tm.next_value_["A"] == train.iloc[-s:]["A"])
 
 
 def test_snaive_predict(generate_ts):
@@ -69,7 +70,8 @@ def test_ma_fit(generate_ts):
 
     tm = MovingAverageForecaster(window=w)
     tm.fit(train)
-    assert tm.next_value_['A'] == train.iloc[-w:]['A'].mean()
+    assert tm.next_value_["A"] == train.iloc[-w:]["A"].mean()
+
 
 def test_ma_predict(generate_ts):
 
@@ -80,7 +82,7 @@ def test_ma_predict(generate_ts):
     tm = MovingAverageForecaster(window=w)
     tm.fit(train)
     expected = pd.DataFrame(train.iloc[-w:].mean().values, index=test.index)
-    assert all(tm.predict(test)== expected.values)
+    assert all(tm.predict(test) == expected.values)
 
 
 # TODO add multi-period tests

--- a/gtime/forecasting/tests/test_simple_models.py
+++ b/gtime/forecasting/tests/test_simple_models.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.util import testing as testing
+
+from gtime.forecasting import NaiveForecaster, SeasonalNaiveForecaster
+
+
+
+@pytest.fixture()
+def generate_ts():
+    testing.N, testing.K = 500, 1
+    df = testing.makeTimeDataFrame(freq="D")
+
+    df["A"] = df["A"] + 0.0005 * pd.Series(
+        index=df.index, data=range(df.shape[0])
+    )
+    return df
+
+
+def test_naive_fit(generate_ts):
+
+    train = generate_ts.iloc[:-1]
+
+    tm = NaiveForecaster()
+    tm.fit(train)
+    assert tm.next_value_['A'] == train.iloc[-1]['A']
+
+
+def test_naive_predict(generate_ts):
+
+    train = generate_ts.iloc[:-1]
+    test = generate_ts.iloc[-1]
+
+    tm = NaiveForecaster()
+    tm.fit(train)
+    expected = pd.DataFrame(data=train.iloc[-1], index=test.index)
+    assert all(tm.predict(test) == expected)
+
+
+def test_snaive_fit(generate_ts):
+
+    s = 12
+    train = generate_ts.iloc[:-1]
+
+    tm = SeasonalNaiveForecaster(seasonal_length=s)
+    tm.fit(train)
+
+    assert all(tm.next_value_['A'] == train.iloc[-s:]['A'])
+
+
+# def test_snaive_predict(generate_ts):
+#
+#     s = 12
+#     test_len = 3
+#     train = generate_ts.iloc[:-test_len]
+#     test = generate_ts.iloc[-test_len:]
+#
+#     tm = SeasonalNaiveForecaster(seasonal_length=s)
+#
+#     tm.fit(train)
+#     print(train.iloc[-s:-s+test_len])
+#     print(tm.predict(test))
+#     expected = pd.DataFrame(train.iloc[-s:-s+test_len], index=test.index)
+#     print(expected)
+#     assert all(tm.predict(test) == expected)

--- a/gtime/forecasting/tests/test_simple_models.py
+++ b/gtime/forecasting/tests/test_simple_models.py
@@ -49,18 +49,17 @@ def test_snaive_fit(generate_ts):
     assert all(tm.next_value_['A'] == train.iloc[-s:]['A'])
 
 
-# def test_snaive_predict(generate_ts):
-#
-#     s = 12
-#     test_len = 3
-#     train = generate_ts.iloc[:-test_len]
-#     test = generate_ts.iloc[-test_len:]
-#
-#     tm = SeasonalNaiveForecaster(seasonal_length=s)
-#
-#     tm.fit(train)
-#     print(train.iloc[-s:-s+test_len])
-#     print(tm.predict(test))
-#     expected = pd.DataFrame(train.iloc[-s:-s+test_len], index=test.index)
-#     print(expected)
-#     assert all(tm.predict(test) == expected)
+def test_snaive_predict(generate_ts):
+
+    s = 12
+    train = generate_ts.iloc[:-1]
+    test = generate_ts.iloc[-1:]
+
+    tm = SeasonalNaiveForecaster(seasonal_length=s)
+
+    tm.fit(train)
+    expected = pd.DataFrame(train.iloc[-s].values, index=test.index)
+    assert all(tm.predict(test).values == expected.values)
+
+
+# TODO add multi-period tests

--- a/gtime/forecasting/tests/test_simple_models.py
+++ b/gtime/forecasting/tests/test_simple_models.py
@@ -63,6 +63,22 @@ def test_snaive_predict(generate_ts):
     assert all(tm.predict(test).values == expected.values)
 
 
+def test_snaive_predict_multiperiod(generate_ts):
+
+    s = 12
+    horizon = 3
+    train = generate_ts.iloc[:-horizon]
+    test = generate_ts.iloc[-horizon:]
+
+    tm = SeasonalNaiveForecaster(seasonal_length=s)
+
+    tm.fit(train)
+    expected = pd.DataFrame(
+        train.iloc[-s : -s + horizon].to_numpy(), index=test.index, columns=test.columns
+    )
+    assert all(tm.predict(test) == expected)
+
+
 def test_ma_fit(generate_ts):
 
     w = 10
@@ -81,8 +97,24 @@ def test_ma_predict(generate_ts):
 
     tm = MovingAverageForecaster(window=w)
     tm.fit(train)
-    expected = pd.DataFrame(train.iloc[-w:].mean().values, index=test.index)
-    assert all(tm.predict(test) == expected.values)
+    expected = pd.DataFrame(
+        train.iloc[-w:].mean().values, index=test.index, columns=test.columns
+    )
+    assert all(tm.predict(test) == expected)
 
 
-# TODO add multi-period tests
+def test_ma_predict_multiperiod(generate_ts):
+
+    w = 10
+    horizon = 3
+    train = generate_ts.iloc[:-horizon]
+    test = generate_ts.iloc[-horizon:]
+
+    tm = MovingAverageForecaster(window=w)
+    tm.fit(train)
+    expected = pd.DataFrame(
+        np.tile(train.iloc[-w:].mean().to_numpy(), (len(test), 1)),
+        index=test.index,
+        columns=test.columns,
+    )
+    assert all(tm.predict(test) == expected)

--- a/gtime/forecasting/tests/test_simple_models.py
+++ b/gtime/forecasting/tests/test_simple_models.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from pandas.util import testing as testing
 
-from gtime.forecasting import NaiveForecaster, SeasonalNaiveForecaster
+from gtime.forecasting import NaiveForecaster, SeasonalNaiveForecaster, MovingAverageForecaster
 
 
 
@@ -60,6 +60,27 @@ def test_snaive_predict(generate_ts):
     tm.fit(train)
     expected = pd.DataFrame(train.iloc[-s].values, index=test.index)
     assert all(tm.predict(test).values == expected.values)
+
+
+def test_ma_fit(generate_ts):
+
+    w = 10
+    train = generate_ts.iloc[:-1]
+
+    tm = MovingAverageForecaster(window=w)
+    tm.fit(train)
+    assert tm.next_value_['A'] == train.iloc[-w:]['A'].mean()
+
+def test_ma_predict(generate_ts):
+
+    w = 10
+    train = generate_ts.iloc[:-1]
+    test = generate_ts.iloc[-1:]
+
+    tm = MovingAverageForecaster(window=w)
+    tm.fit(train)
+    expected = pd.DataFrame(train.iloc[-w:].mean().values, index=test.index)
+    assert all(tm.predict(test)== expected.values)
 
 
 # TODO add multi-period tests


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-time/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Adds simple forecast model classes, see https://github.com/giotto-ai/giotto-time/wiki/Traditional-forecasting-models


#### What does this implement/fix? Explain your changes.
Adds naïve, seasonal naïve and simple average forecast models (3 new classes in forecasting), all inherit from BaseEstimator and RegressorMixin and are sklearn-compatible.

#### Any other comments?


<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
